### PR TITLE
Fetch specific versions of Javadocs instead of the latest

### DIFF
--- a/scripts/downloadJavadocs.sh
+++ b/scripts/downloadJavadocs.sh
@@ -8,33 +8,38 @@ korypheVersion=$3
 # Update javadocs
 mkdir -p docs/javadoc
 cd docs/javadoc
+
+fetchJavadoc () {
+    rm -rf $1
+    restUrl='https://api.github.com/repos/gchq/'$1'/commits?sha=gh-pages' #Requests to this API are ratelimited without a token
+    commitShaRegex='.*message.*'$2'.,.*.tree...{.*sha....([[:alnum:]]*).,'
+    githubCommitHistory=$(curl -Ss -H "Accept: application/vnd.github.v3+json" $restUrl)
+    if [[ "$githubCommitHistory" =~ $commitShaRegex ]]; then
+        commitSha="${BASH_REMATCH[1]}"
+    else
+        echo 'Error finding '$1' Javadoc for version '$2
+        echo 'curl output:'$githubCommitHistory
+        exit 1
+    fi
+    curl -Ss -L 'https://github.com/gchq/'$1'/archive/'$commitSha'.zip' > $1.zip
+    unzip -q $1.zip
+    mv *-$commitSha $1
+    rm $1.zip
+    echo '' > $1/$2
+}
+
 if [ ! -f gaffer/$gafferVersion ]; then
-    rm -rf gaffer
-    curl -L https://github.com/gchq/Gaffer/tarball/gh-pages > gaffer.tar.gz
-    tar -xvf gaffer.tar.gz
-    mv gchq-Gaffer-* gaffer
-    rm -rf gaffer.tar.gz
-    echo '' > gaffer/$gafferVersion
+    fetchJavadoc 'gaffer' $gafferVersion
 else
     echo 'Gaffer Javadoc already up to date'
 fi
 if [ ! -f gaffer-tools/$gafferToolsVersion ]; then
-    rm -rf gaffer-tools
-    curl -L https://github.com/gchq/gaffer-tools/tarball/gh-pages > gaffer-tools.tar.gz
-    tar -xvf gaffer-tools.tar.gz
-    mv gchq-gaffer-tools-* gaffer-tools
-    rm -rf gaffer-tools.tar.gz
-    echo '' > gaffer-tools/$gafferToolsVersion
+    fetchJavadoc 'gaffer-tools' $gafferToolsVersion
 else
     echo 'Gaffer Tools Javadoc already up to date'
 fi
 if [ ! -f koryphe/$korypheVersion ]; then
-    rm -rf koryphe
-    curl -L https://github.com/gchq/koryphe/tarball/gh-pages > koryphe.tar.gz
-    tar -xvf koryphe.tar.gz
-    mv gchq-koryphe-* koryphe
-    rm -rf koryphe.tar.gz
-    echo '' > koryphe/$korypheVersion
+    fetchJavadoc 'koryphe' $korypheVersion
 else
     echo 'Koryphe Javadoc already up to date'
 fi


### PR DESCRIPTION
Instead of getting the latest commit from gh-pages, search for the commit for the version required (using the GitHub API) and fetch that version instead. Tidy up the script by moving most duplicate code into a function.